### PR TITLE
Grasping action for clutter clearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Noteable/major changes will be listed here
 
 - planner now checks if arm needs to re-initialise end effector position when replanning.
 - end effector starting x-position is used as a limit when checking for objects to clear.
+- grasping action implemented.
+  - added getGraspAction() method.
+  - added executeAction() method, this essentially just determines initial and final states of the gripper based on the action type and splits the trajectory for the action if needed.
+- when planning a push action, static collision check for the pushed object is performed.
+
+### Modified
+
+- path_valid bool in start_plan srv replaced with partial_solution bool.
 
 ## 16th Feb 2021
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,10 @@
-- [ ] Add checks for static objects when planning to clear a path
+- [x] Add checks for static objects when planning to clear a path
   - [x] for pushing actions
-  - [ ] for grasping actions
-- [ ] Consider objects that are not blocking the object but may block the arm while clearing a path to reach the object
+  - [x] for grasping actions
+- [x] Consider objects that are not blocking the object but may block the arm while clearing a path to reach the object
   - [x] objects directly behind goal 
-  - [ ] objects outside defined workspace
-- [ ] Add grasping as a clutter clearing action
+  - [ ] ~~objects outside defined workspace~~
+- [x] Add grasping as a clutter clearing action
 - [x] Add execution time logging
 - [x] use ROS params for planner timeouts, name, IK solve type etc.
 - [x] Write up a complete README

--- a/planner/include/planner/planner.h
+++ b/planner/include/planner/planner.h
@@ -34,7 +34,6 @@ namespace og = ompl::geometric;
 class Planner
 {
 public:
-    // TODO: use this in implementation
     enum ActionType
     {
         NONE = -1,
@@ -82,7 +81,9 @@ private:
     Planner::ActionType planInClutter(std::vector<int> idxs, std::vector<ob::ScopedState<ob::SE3StateSpace>>& states);
     bool getPushAction(std::vector<ob::ScopedState<ob::SE3StateSpace>>& states, std::vector<util::CollisionGeometry>& objs,
         const util::CollisionGeometry& geom);
+    bool getGraspAction(std::vector<ob::ScopedState<ob::SE3StateSpace>>& states, const util::CollisionGeometry& geom);
     bool getPushGraspAction(const util::CollisionGeometry& geom, ob::ScopedState<ob::SE3StateSpace>& state);
+    void executeAction(Planner::ActionType action);
     bool startPlanSrvCallback(planner::start_plan::Request& req, planner::start_plan::Response& res);
 
     ros::NodeHandle nh_;

--- a/planner/include/planner/planner.h
+++ b/planner/include/planner/planner.h
@@ -45,14 +45,14 @@ public:
     typedef struct PlannerResult
     {
         bool path_found = false;
-        bool path_valid = false;
+        bool partial_solution = false;
         bool grasp_success = false;
         double plan_time = 0.0;
         double execution_time = 0.0;
 
         void reset()
         {
-            path_found = path_valid = grasp_success = false;
+            path_found = partial_solution = grasp_success = false;
             plan_time = execution_time = 0.0;
         }
     } PlannerResult;

--- a/planner/src/planner.cpp
+++ b/planner/src/planner.cpp
@@ -642,7 +642,7 @@ bool Planner::isObjectBlocked(std::vector<int>& idxs)
         bool is_static = std::any_of(static_objs_.begin(), static_objs_.end(), [this, i](const std::string& str)
             { return collision_boxes_[i].name.find(str) != std::string::npos; });
 
-        bool out_of_workspace = std::abs(collision_boxes_[i].pose.position.x) > std::abs(goal_pos_.x()) ||
+        bool out_of_workspace = std::abs(collision_boxes_[i].pose.position.x) > std::abs(goal_pos_.x()) + 0.1 ||
             std::abs(collision_boxes_[i].pose.position.x) < std::abs(start->getX()) ||
             std::abs(collision_boxes_[i].pose.position.y - goal_pos_.y()) > 0.3 ||
             std::abs(collision_boxes_[i].pose.position.z - goal_pos_.z()) > 0.2;
@@ -882,6 +882,9 @@ bool Planner::startPlanSrvCallback(planner::start_plan::Request& req, planner::s
 
     if (req.target.find("_collision") == std::string::npos) req.target += "_collision";
 
+    controller_.goToInit();
+    controller_.openGripper();
+    
     target_geom_.name = req.target;
     target_geom_.dimension.x = target_geom_.dimension.y = target_geom_.dimension.z = -1;
     this->update();
@@ -905,9 +908,6 @@ bool Planner::startPlanSrvCallback(planner::start_plan::Request& req, planner::s
         res.message = "Unable to start, target is out of reach!";
         return true;
     }
-
-    controller_.goToInit();
-    controller_.openGripper();
 
     std::vector<Eigen::Vector3d> start_positions; std::vector<Eigen::Quaterniond> start_orientations;
     manipulator_.solveFK(start_positions, start_orientations);

--- a/planner/src/planner.cpp
+++ b/planner/src/planner.cpp
@@ -65,7 +65,7 @@ bool Planner::plan()
             Planner::ActionType action = this->planInClutter(blocking_objs, states);
             if (action == Planner::ActionType::NONE)
             {
-                result_.path_found = result_.path_valid = result_.grasp_success = false;
+                result_.partial_solution = true;
                 result_.plan_time = plan_timer.elapsedMillis()/1000.0;
                 result_.execution_time = exectuion_timer.elapsedMillis()/1000.0;
                 ROS_ERROR("[PLANNER]: Failed to plan an action!");
@@ -117,7 +117,7 @@ bool Planner::plan()
             trajectory_msgs::JointTrajectory traj;
             if (!this->generateTrajectory(traj))
             {
-                result_.path_valid = result_.grasp_success = false;
+                result_.partial_solution = true;
                 result_.plan_time = plan_timer.elapsedMillis()/1000.0;
                 result_.execution_time = exectuion_timer.elapsedMillis()/1000.0;
                 std::cout << "[PLANNER]: Path not kinematically valid!" << std::endl;
@@ -148,7 +148,7 @@ bool Planner::plan()
         trajectory_msgs::JointTrajectory traj;
         if (!this->generateTrajectory(traj))
         {
-            result_.path_valid = result_.grasp_success = false;
+            result_.partial_solution = true;
             result_.plan_time = plan_timer.elapsedMillis()/1000.0;
             std::cout << "[PLANNER]: Path not kinematically valid!" << std::endl;
             return false;
@@ -164,7 +164,7 @@ bool Planner::plan()
 
     result_.plan_time = plan_timer.elapsedMillis()/1000.0;
     result_.execution_time = exectuion_timer.elapsedMillis()/1000.0;
-    result_.path_valid = result_.path_found = true;
+    result_.path_found = true;
 
     std::cout << GREEN << "[PLANNER]: Solution found!\n";
 
@@ -1044,7 +1044,7 @@ bool Planner::startPlanSrvCallback(planner::start_plan::Request& req, planner::s
                                             target_geom_.pose.position.y,
                                             target_geom_.pose.position.z);
 
-    res.path_found = res.path_valid = res.grasp_success = false;
+    res.path_found = res.partial_solution = res.grasp_success = false;
     res.plan_time = res.execution_time = 0.0;
 
     if (target_geom_.dimension.x == -1)
@@ -1069,13 +1069,13 @@ bool Planner::startPlanSrvCallback(planner::start_plan::Request& req, planner::s
         << "execution time: " << result_.execution_time << " s" << std::endl;
 
     res.path_found = result_.path_found;
-    res.path_valid = result_.path_valid;
+    res.partial_solution = result_.partial_solution;
     res.grasp_success = result_.grasp_success;
     res.plan_time = result_.plan_time;
     res.execution_time = result_.execution_time;
 
     if (!res.path_found) { res.message = "Unable to find solution!"; }
-    else if (!res.path_valid) { res.message = "Solution path found but is not kinematically valid!"; }
+    else if (!res.partial_solution) { res.message = "Only found partial solution!"; }
     else if (res.grasp_success) { res.message = "Solution found and grasp attempt was successful!"; }
     else { res.message = "Solution found but grasp attempt failed!"; }
 

--- a/planner/srv/start_plan.srv
+++ b/planner/srv/start_plan.srv
@@ -2,7 +2,7 @@ string target
 ---
 string message
 bool path_found
-bool path_valid
+bool partial_solution
 bool grasp_success
 float64 plan_time
 float64 execution_time

--- a/planner/test/tester.cpp
+++ b/planner/test/tester.cpp
@@ -115,7 +115,7 @@ private:
             
             // annoyingly, bool variables in ROS srv/msg are represented as uint8, so each one needs to
             // be cast to bool type to print them out correctly
-            file << bool(plan_req.response.path_found) << "," << bool(plan_req.response.path_valid) << ","
+            file << bool(plan_req.response.path_found) << "," << bool(plan_req.response.partial_solution) << ","
                 << bool(plan_req.response.grasp_success) << "," << plan_req.response.plan_time << ","
                 << plan_req.response.execution_time << std::endl;
 


### PR DESCRIPTION
- Fixed initialisation issues when the planner sets start position without first re-initialising the arm
- Fixed objects behind target (also beside it) being ignored
- Grasping action implemented, closes #25 
- Collision checking with static objects for pushed objects added
- Replaced path_valid bool in the start_plan service with partial_solution