### PR TITLE
Add global timeout, number of actions logging, and randomiser updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Noteable/major changes will be listed here
 
+## 2nd March 2021
+
+### Added
+
+- Number of actions executed are now logged
+- Added a global timeout, the planner will timeout if execution time + planning exceeds this.
+
 ## 23rd Feb 2021
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Noteable/major changes will be listed here
 
+## 23rd Feb 2021
+
+### Added
+
+- Gazebo scene randomiser plugin srv returns number of objects in the scene, surface area, and the free area left on the surface.
+
 ## 22nd Feb 2021
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -8,8 +8,9 @@
 - [x] Add execution time logging
 - [x] use ROS params for planner timeouts, name, IK solve type etc.
 - [x] Write up a complete README
+- [ ] Add search method for suitable locations to drop grasped objects
 - [ ] Add media files
-- [ ] Add number of actions logging
+- [x] Add number of actions logging
 - [ ] Add some form of grasp pose generation
 - [x] Add script to randomise Gazebo environment and execute the planner
   - [x] scene randomiser

--- a/TODO.md
+++ b/TODO.md
@@ -9,6 +9,8 @@
 - [x] use ROS params for planner timeouts, name, IK solve type etc.
 - [x] Write up a complete README
 - [ ] Add media files
+- [ ] Add number of actions logging
+- [ ] Add some form of grasp pose generation
 - [x] Add script to randomise Gazebo environment and execute the planner
   - [x] scene randomiser
   - [x] node to automate planner execution

--- a/gazebo_scene_randomiser_plugin/README.md
+++ b/gazebo_scene_randomiser_plugin/README.md
@@ -4,9 +4,8 @@ A plugin to randomise objects in the world on a given surface. Objects that have
 This plugin was developed while working on a 3rd Year Project at the University of Leeds for manipulation planning in cluttered environments.
 
 User's interface with the plugin is through a ROS service. The plugin takes in the name of a collision link (the surface) and randomises the pose of all the 
-objects in the world on that surface. For position, the x and y values are changed, and for rotation, the z-axis rotation (yaw) is changed.
-
-**IMPORTANT:** Make the surface has its z-axis aligned with the world z-axis and has the same direction. The surface yaw can be changed, but roll and pitch must be zero.
+objects in the world on that surface. For position, the x and y values are changed, and for rotation, the z-axis rotation (yaw) is changed.  
+The plugin will return the number of objects in the scene and the free space left on the surface.
 
 The robot name must be set as a parameter on ```/robot_name``` so that the plugin can avoid changing the robot pose.
 
@@ -18,12 +17,29 @@ As an example:
 </world>
 ```
 
-## Usage
+## Limitations
+- The plugin only supports box and cylinder shaped surfaces.
+- The object areas are calculated using their shapes **if** they have one collision link named ```collision``` and are box or cylinder shapes, otherwise an Axis-Aligned Bounding Box is used.
+- Surface parent models must use ```_link_``` to indicate child links.
+- Make the surface has its z-axis aligned with the world z-axis and has the same direction. The surface yaw can be changed, but roll and pitch must be zero.
+
+## The Randomise Service
+### Input
+- ```string surface``` - surface name
+
+### Output
+- ```bool success``` - boolean indicating success/failure to randomise scene.
+- ```string message``` - output message.
+- ```int8 num_objects``` - number of objects in scene.
+- ```float64 surface_area``` - area of the surface, regardless of what is on it.
+- ```float64 free_area``` - free area left on the surface.
+
+### Usage
 The plugin service is advertised on ```/gazebo/randomise_scene``` and it takes one parameter, ```surface```, which is the name of the surface.
 
 If using through the command line, simply use:
 ```
-rosservice call /gazebo/randomise_scene "surface: 'name'"
+$ rosservice call /gazebo/randomise_scene "surface: 'name'"
 ```
 
 Replace ```name``` with the name of a surface. For example, the table model in Gazebo would be ```table_link_surface``` or for one of the shelves on a bookshelf model, ```bookshelf_link_low_shelf```.

--- a/gazebo_scene_randomiser_plugin/include/gazebo_scene_randomiser_plugin/scene_randomiser_plugin.h
+++ b/gazebo_scene_randomiser_plugin/include/gazebo_scene_randomiser_plugin/scene_randomiser_plugin.h
@@ -23,7 +23,7 @@ namespace gazebo
         void Load(physics::WorldPtr _world, sdf::ElementPtr _sdf);
 
     private:
-        void queueThread();
+        double getModelArea(physics::ModelPtr model);
         bool checkCollision(ignition::math::v4::Pose3d& pose, physics::ModelPtr model, physics::ModelPtr parent);
         ignition::math::v4::Pose3d getModelPose(const ignition::math::v4::Pose3d& centre, physics::ShapePtr shape);
         bool randomiseSrvCallback(gazebo_scene_randomiser_plugin::randomiseRequest& req, gazebo_scene_randomiser_plugin::randomiseResponse& res);

--- a/gazebo_scene_randomiser_plugin/src/scene_randomiser_plugin.cpp
+++ b/gazebo_scene_randomiser_plugin/src/scene_randomiser_plugin.cpp
@@ -109,7 +109,7 @@ ignition::math::v4::Pose3d SceneRandomiser::getModelPose(const ignition::math::v
         // the surface dimensions are reduced to avoid cases with objects
         // being on the edge
         ignition::math::v4::Vector3d dim(box->Size());
-        dim.X() -= 0.2, dim.Y() -= 0.2;
+        dim.X() -= 0.1, dim.Y() -= 0.1;
 
         double upper_x = centre.Pos().X() + (dim.X()*0.5);
         double lower_x = centre.Pos().X() - (dim.X()*0.5);

--- a/gazebo_scene_randomiser_plugin/srv/randomise.srv
+++ b/gazebo_scene_randomiser_plugin/srv/randomise.srv
@@ -2,3 +2,6 @@ string surface
 ---
 bool success
 string message
+int16 num_objects
+float64 surface_area
+float64 free_area

--- a/planner/include/planner/planner.h
+++ b/planner/include/planner/planner.h
@@ -47,13 +47,14 @@ public:
         bool path_found = false;
         bool partial_solution = false;
         bool grasp_success = false;
+        int num_actions = 0;
         double plan_time = 0.0;
         double execution_time = 0.0;
 
         void reset()
         {
             path_found = partial_solution = grasp_success = false;
-            plan_time = execution_time = 0.0;
+            num_actions = plan_time = execution_time = 0.0;
         }
     } PlannerResult;
 

--- a/planner/include/planner/planner.h
+++ b/planner/include/planner/planner.h
@@ -93,6 +93,7 @@ private:
     ros::ServiceClient collisions_client_;
 
     bool save_path_;
+    int global_timeout_;
     int timeout_;
     int path_states_;
     std::string planner_name_;

--- a/planner/params/params.yaml
+++ b/planner/params/params.yaml
@@ -1,9 +1,10 @@
 planner:
-  name:           'KPIECE1'       # RRTStar or BFMT or KPIECE1
-  timeout:        60              # seconds
-  path_states:    8              # paths will be interpolated if they have less states than this
-  save_path:      false
+  name:             'KPIECE1'       # RRTStar or BFMT or KPIECE1
+  global_timeout:   300             # seconds, overall timeout for execution + planning time in clutter
+  timeout:          60              # seconds, timeout for motion planning only
+  path_states:      8               # paths will be interpolated if they have less states than this
+  save_path:        false
 
 kinematics_solver:
-  type:           1               # 0 - Speed, 1 - Distance, 2 - Manip1, 3 - Manip2
-  timeout:        0.005           # seconds
+  type:             1               # 0 - Speed, 1 - Distance, 2 - Manip1, 3 - Manip2
+  timeout:          0.005           # seconds

--- a/planner/src/planner.cpp
+++ b/planner/src/planner.cpp
@@ -361,7 +361,7 @@ void Planner::initROS()
 
     if (planner_name_ != "KPIECE1" && planner_name_ != "BFMT" && planner_name_ != "RRTStar")
     {
-        ROS_WARN("[PLANNER]: unrecognised planner name [%s], setting to KPIECE1!", planner_name_);
+        ROS_WARN("[PLANNER]: unrecognised planner name [%s], setting to KPIECE1!", planner_name_.c_str());
         planner_name_ = "KPIECE1";
         ros::param::set("~planner/name", "KPIECE1");
     }

--- a/planner/src/planner.cpp
+++ b/planner/src/planner.cpp
@@ -1075,7 +1075,7 @@ bool Planner::startPlanSrvCallback(planner::start_plan::Request& req, planner::s
     res.execution_time = result_.execution_time;
 
     if (!res.path_found) { res.message = "Unable to find solution!"; }
-    else if (!res.partial_solution) { res.message = "Only found partial solution!"; }
+    else if (res.partial_solution) { res.message = "Only found partial solution!"; }
     else if (res.grasp_success) { res.message = "Solution found and grasp attempt was successful!"; }
     else { res.message = "Solution found but grasp attempt failed!"; }
 

--- a/planner/src/planner.cpp
+++ b/planner/src/planner.cpp
@@ -138,12 +138,15 @@ bool Planner::plan()
             plan_timer.pause();
 
             exectuion_timer.start();
+            result_.num_actions++;
             this->executeAction(action);
             exectuion_timer.pause();
         }
     }
     else
     {
+        result_.num_actions++;
+
         // object not blocked but path may collide with non-static objects because
         // initial planning does not check for that, so path needs to be checked
         state_checker_->setNonStaticCollisions(true);
@@ -1053,12 +1056,8 @@ bool Planner::startPlanSrvCallback(planner::start_plan::Request& req, planner::s
     target_geom_.dimension.x = target_geom_.dimension.y = target_geom_.dimension.z = -1;
     this->update();
 
-    Eigen::Vector3d goal_xyz = Eigen::Vector3d(target_geom_.pose.position.x,
-                                            target_geom_.pose.position.y,
-                                            target_geom_.pose.position.z);
-
     res.path_found = res.partial_solution = res.grasp_success = false;
-    res.plan_time = res.execution_time = 0.0;
+    res.plan_time = res.execution_time = res.num_actions = 0.0;
 
     if (target_geom_.dimension.x == -1)
     {
@@ -1066,7 +1065,7 @@ bool Planner::startPlanSrvCallback(planner::start_plan::Request& req, planner::s
         res.message = "Unable to start, target not found!";
         return true;
     }
-    else if (std::sqrt((goal_xyz.x()*goal_xyz.x()) + (goal_xyz.y()*goal_xyz.y()) + (goal_xyz.z()*goal_xyz.z())) > 0.95)
+    else if (std::sqrt((goal_pos_.x()*goal_pos_.x()) + (goal_pos_.y()*goal_pos_.y()) + (goal_pos_.z()*goal_pos_.z())) > 0.95)
     {
         ROS_ERROR("[PLANNER]: Target is out of reach!");
         res.message = "Unable to start, target is out of reach!";
@@ -1081,6 +1080,7 @@ bool Planner::startPlanSrvCallback(planner::start_plan::Request& req, planner::s
     res.path_found = result_.path_found;
     res.partial_solution = result_.partial_solution;
     res.grasp_success = result_.grasp_success;
+    res.num_actions = result_.num_actions;
     res.plan_time = result_.plan_time;
     res.execution_time = result_.execution_time;
 

--- a/planner/srv/start_plan.srv
+++ b/planner/srv/start_plan.srv
@@ -4,5 +4,6 @@ string message
 bool path_found
 bool partial_solution
 bool grasp_success
+int8 num_actions
 float64 plan_time
 float64 execution_time

--- a/planner/test/tester.cpp
+++ b/planner/test/tester.cpp
@@ -118,9 +118,9 @@ private:
             // be cast to bool type to print them out correctly
             file << std::fixed << std::setprecision(3) << bool(plan_req.response.path_found) << ","
                 << bool(plan_req.response.partial_solution) << "," << bool(plan_req.response.grasp_success)
-                << "," << plan_req.response.plan_time << "," << plan_req.response.execution_time << ","
-                << randomise_req.response.num_objects << "," << randomise_req.response.free_area << ","
-                << randomise_req.response.surface_area << "\n";
+                << "," << plan_req.response.num_actions << "," << plan_req.response.plan_time << ","
+                << plan_req.response.execution_time << "," << randomise_req.response.num_objects << ","
+                << randomise_req.response.free_area << "," << randomise_req.response.surface_area << "\n";
 
             file.flush();
             file.close();

--- a/planner/test/tester.cpp
+++ b/planner/test/tester.cpp
@@ -1,4 +1,5 @@
 #include <fstream>
+#include <iomanip>
 #include <planner/start_plan.h>
 #include <gazebo_scene_randomiser_plugin/randomise.h>
 #include <ros/ros.h>
@@ -115,9 +116,11 @@ private:
             
             // annoyingly, bool variables in ROS srv/msg are represented as uint8, so each one needs to
             // be cast to bool type to print them out correctly
-            file << bool(plan_req.response.path_found) << "," << bool(plan_req.response.partial_solution) << ","
-                << bool(plan_req.response.grasp_success) << "," << plan_req.response.plan_time << ","
-                << plan_req.response.execution_time << std::endl;
+            file << std::fixed << std::setprecision(3) << bool(plan_req.response.path_found) << ","
+                << bool(plan_req.response.partial_solution) << "," << bool(plan_req.response.grasp_success)
+                << "," << plan_req.response.plan_time << "," << plan_req.response.execution_time << ","
+                << randomise_req.response.num_objects << "," << randomise_req.response.free_area << ","
+                << randomise_req.response.surface_area << "\n";
 
             file.flush();
             file.close();


### PR DESCRIPTION
- updated the randomiser plugin srv to return scene data. (the number of objects in the scene, area of the surface, and the free area remaining)
- added global timeout and logging for number of actions, closes #30 