### PR TITLE
Grid search for object relocation positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 Noteable/major changes will be listed here
 
+## 15th March 2021
+
+### Added
+
+- discretisation of work surface into 2D grid.
+- publishing of nav_msgs::OccupancyGrid to visualise discretisation.
+- search method to evaluate grid cells to find relocation position for a grasped object.
+
+### Modified
+
+- surface name is now a ROS param that is set by the user when launching Gazebo.
+
+### Removed
+
+- setCollisionGeometries() method in Planner class. Functions was replaced with update(), should've removed it earlier...
+
 ## 10th March 2021
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ There are two parameters files, one for [Gazebo](kinova_gazebo/params/gazebo_par
 ### Gazebo Parameters
 - ```gazebo/static_objects``` - string array containing which objects are to be considered static, these will be displayed in red in Rviz.
 - ```gazebo/pub_arm_geom``` - bool to trigger visualisation of the Kinova's collision boxes in Rviz. (purely visual, doesn't affect anything)
+- ```gazebo/surface``` - the name of the surface that is being worked, this is set during launch. (Check the [demo](#running-a-demo) section for details on launching)
 
 ### Planner Parameters
 - ```planner/name``` - name of the sampling motion planner to be used.
+- ```planner/global_timeout``` - total timeout for planning + execution time in clutter.
 - ```planner/timeout``` - timeout duration for the planner.
 - ```planner/path_states``` - number of states to be interpolated in generated paths.
 - ```planner/save_path``` - bool to trigger saving of solution paths in [paths directory](planner/paths).
@@ -96,10 +98,17 @@ $ roslaunch planner gazebo.launch
 
 A Gazebo and Rviz windows should popup.
 
-If desired, you can pass in a world argument to launch a different scene from the [worlds](kinova_gazebo/worlds) folder. The default is ```kinova_tableV1```.
+If desired, you can pass in a world argument to launch a different scene from the [worlds](kinova_gazebo/worlds) folder. The default is ```kinova_table```.
 ```
-$ roslaunch planner gazebo.launch world:=kinova_tableV2
+$ roslaunch planner gazebo.launch world:=kinova_cabinet surface=cabinet_link_middle_plate
 ```
+
+for more info on obtaining surface names from Gazebo, check the gazebo_scene_randomiser_plugin [README](gazebo_scene_randomiser_plugin/README.md).  
+As a starting point you can use the below surface names for each world file in this repo.
+
+- kinova_table - small_table_link_surface (this is the default)
+- kinova_shelf - bookshelf_link_low_shelf
+- kinova_cabinet - cabinet_link_middle_plate
 
 **NOTE:** if Gazebo models need to be installed, Gazebo node may not launch correctly. Gazebo will take some time to load as it is downloading required models, once loaded the arm will probably just fall due to controller timeout. Resolved by relaunching after Gazebo finishes downloading models and loads up.  
 
@@ -116,7 +125,15 @@ The arm will not do anything until a planning request for a specific target is s
 $ rosservice call /start_plan "target: 'object_name'" 
 ```
 
-Replace **object_name** with the name of an object in Gazebo. This must be a non-static object.
+Replace ```object_name``` with the name of an object in Gazebo. This must be a non-static object. As a start use ```cylinder``` which is the green cylinder in the world files in this repo.
+
+Alternatively, you can use the testing node to perform multiple runs:
+
+```
+$ roslaunch planner tester.launch num_runs:=number
+```
+
+Replace ```number``` with the number of runs you want to do.
 
 ## Third Party Packages
 All third party licenses can be found in their respective folders in this repository and their original repositories linked below.

--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,9 @@
 - [x] Add execution time logging
 - [x] use ROS params for planner timeouts, name, IK solve type etc.
 - [x] Write up a complete README
-- [ ] Add search method for suitable locations to drop grasped objects
+- [x] Add search method for suitable locations to drop grasped objects
+  - [x] Surface discretisation
+  - [x] Surface search
 - [ ] Add media files
 - [x] Add number of actions logging
 - [x] Add some form of grasp pose generation

--- a/kinova_gazebo/launch/robot_launch.launch
+++ b/kinova_gazebo/launch/robot_launch.launch
@@ -11,10 +11,12 @@
   <arg name="debug" default="false"/>
   <arg name="use_trajectory_controller" default="true"/>
   <arg name="is7dof" default="true"/>
+  <arg name="surface" default="small_table_link_surface"/>
 
   <!-- put relevant parameters up on the parameter server -->
   <rosparam command="load"  file="$(find kinova_gazebo)/params/gazebo_params.yaml" />
   <param name="robot_name"  type="string"   value="$(arg kinova_robotName)" />
+  <param name="/gazebo/surface"     type="string"   value="$(arg surface)" />
 
   <!-- We resume the logic in empty_world.launch, changing only the name of the world to be launched -->
   <include file="$(find gazebo_ros)/launch/empty_world.launch">

--- a/kinova_gazebo/rviz/j2n6s300.rviz
+++ b/kinova_gazebo/rviz/j2n6s300.rviz
@@ -102,6 +102,16 @@ Visualization Manager:
         {}
       Queue Size: 100
       Value: true
+    - Alpha: 0.699999988079071
+      Class: rviz/Map
+      Color Scheme: map
+      Draw Behind: false
+      Enabled: true
+      Name: Map
+      Topic: /surface_grid
+      Unreliable: false
+      Use Timestamp: false
+      Value: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48

--- a/kinova_gazebo/rviz/j2s6s300.rviz
+++ b/kinova_gazebo/rviz/j2s6s300.rviz
@@ -102,6 +102,16 @@ Visualization Manager:
         {}
       Queue Size: 100
       Value: true
+    - Alpha: 0.699999988079071
+      Class: rviz/Map
+      Color Scheme: map
+      Draw Behind: false
+      Enabled: true
+      Name: Map
+      Topic: /surface_grid
+      Unreliable: false
+      Use Timestamp: false
+      Value: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48

--- a/kinova_gazebo/rviz/j2s7s300.rviz
+++ b/kinova_gazebo/rviz/j2s7s300.rviz
@@ -183,6 +183,16 @@ Visualization Manager:
         geometries: true
       Queue Size: 100
       Value: true
+    - Alpha: 0.699999988079071
+      Class: rviz/Map
+      Color Scheme: map
+      Draw Behind: false
+      Enabled: true
+      Name: Map
+      Topic: /surface_grid
+      Unreliable: false
+      Use Timestamp: false
+      Value: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48

--- a/planner/CMakeLists.txt
+++ b/planner/CMakeLists.txt
@@ -83,7 +83,7 @@ include_directories(
   ${fcl_INCLUDE_DIRS}
 )
 
-add_executable(planner_node src/node.cpp src/controller.cpp src/planner.cpp src/manipulator.cpp src/timer.cpp src/util.cpp)
+add_executable(planner_node src/node.cpp src/controller.cpp src/planner.cpp src/manipulator.cpp src/timer.cpp src/util.cpp src/state_validity.cpp)
 add_dependencies(planner_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(planner_node
   ${catkin_LIBRARIES}

--- a/planner/CMakeLists.txt
+++ b/planner/CMakeLists.txt
@@ -31,6 +31,7 @@ find_package(catkin REQUIRED COMPONENTS
   actionlib
   gazebo_msgs
   sensor_msgs
+  nav_msgs
   trac_ik_lib
   gazebo_geometries_plugin
   gazebo_scene_randomiser_plugin
@@ -82,7 +83,7 @@ include_directories(
   ${fcl_INCLUDE_DIRS}
 )
 
-add_executable(planner_node src/node.cpp src/controller.cpp src/planner.cpp src/manipulator.cpp src/timer.cpp)
+add_executable(planner_node src/node.cpp src/controller.cpp src/planner.cpp src/manipulator.cpp src/timer.cpp src/util.cpp)
 add_dependencies(planner_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(planner_node
   ${catkin_LIBRARIES}

--- a/planner/include/planner/planner.h
+++ b/planner/include/planner/planner.h
@@ -67,7 +67,6 @@ public:
     bool plan();
     void setStart(const Eigen::Vector3d& start, const Eigen::Quaterniond& orientation);
     void setGoal(const Eigen::Vector3d& goal, const Eigen::Quaterniond& orientation);
-    void setCollisionGeometries(const std::vector<util::CollisionGeometry>& collision_boxes);
     void setTargetGeometry(util::CollisionGeometry geom);
     void savePath();
     void clearMarkers();

--- a/planner/include/planner/planner.h
+++ b/planner/include/planner/planner.h
@@ -5,6 +5,7 @@
 #include <eigen3/Eigen/Geometry>
 #include <boost/filesystem.hpp>
 #include <visualization_msgs/Marker.h>
+#include <nav_msgs/OccupancyGrid.h>
 #include <trajectory_msgs/JointTrajectory.h>
 #include <gazebo_geometries_plugin/geometry.h>
 #include <gazebo_msgs/ModelStates.h>
@@ -76,6 +77,7 @@ private:
     void initROS();
     bool generateTrajectory(trajectory_msgs::JointTrajectory& traj);
     void publishGoalMarker();
+    void publishGridMap();
     void publishMarkers();
     void modelStatesCallback(gazebo_msgs::ModelStatesConstPtr msg);
     void update();
@@ -94,6 +96,7 @@ private:
 
     ros::NodeHandle nh_;
     ros::Publisher marker_pub_;
+    ros::Publisher grid_pub_;
     ros::Subscriber models_sub_;
     ros::ServiceServer start_plan_srv_;
     ros::ServiceServer reset_arm_srv_;

--- a/planner/include/planner/planner.h
+++ b/planner/include/planner/planner.h
@@ -43,7 +43,7 @@ public:
         GRASP
     };
 
-    typedef struct PlannerResult
+    struct PlannerResult
     {
         bool path_found = false;
         bool partial_solution = false;
@@ -57,7 +57,7 @@ public:
             path_found = partial_solution = grasp_success = false;
             num_actions = plan_time = execution_time = 0.0;
         }
-    } PlannerResult;
+    };
 
 public:
     Planner(ros::NodeHandle* nh);
@@ -110,6 +110,9 @@ private:
 
     PlannerResult result_;
     util::CollisionGeometry target_geom_;
+    util::CollisionGeometry surface_geom_;
+    std::string surface_parent_name_;
+    util::Grid2D surface_grid_;
     gazebo_msgs::ModelStatesConstPtr models_;
 
     std::vector<std::string> static_objs_;

--- a/planner/include/planner/state_validity.h
+++ b/planner/include/planner/state_validity.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ompl/base/StateValidityChecker.h>
+#include <ompl/base/spaces/SE3StateSpace.h>
 #include <ompl/base/MotionValidator.h>
 
 #include <fcl/config.h>
@@ -12,214 +13,21 @@
 #include "manipulator.h"
 
 namespace ob = ompl::base;
-namespace og = ompl::geometric;
 
 class StateChecker : public ob::StateValidityChecker
 {
 public:
-    StateChecker(const ob::SpaceInformationPtr &si, Manipulator* manip, const std::vector<util::CollisionGeometry>* collision_boxes)
-        : ob::StateValidityChecker(si), manipulator_(manip), collision_boxes_(collision_boxes)
-    {
-        target_collision_ = true;
-        non_static_collisions_ = false;
-        check_IK_ = false;
+    StateChecker(const ob::SpaceInformationPtr &si, Manipulator* manip, const std::vector<util::CollisionGeometry>* collision_boxes);
 
-        ros::param::param<std::vector<std::string>>("/gazebo/static_objects", static_objs_, {"INVALID"});
+    void setTargetCollision(bool option);
+    void setNonStaticCollisions(bool option);
+    void setTargetName(std::string name);
+    void setIKCheck(bool option);
+    bool isValid(const ob::State* state) const;
+    bool checkInReach(const ob::State* state) const;
+    bool checkIK(const ob::State* state) const;
+    bool checkCollision(const ob::State* state) const;
 
-        effector_translation_ = Eigen::Vector3d(0, 0.0, -0.12);
-        finger_1_translation_ = Eigen::Vector3d(0.05, 0.0065, -0.032);
-        finger_2_translation_ = Eigen::Vector3d(-0.045, 0.025, -0.032);
-        finger_3_translation_ = Eigen::Vector3d(-0.045, -0.025, -0.032);
-        finger_1_rotation_ = Eigen::Quaterniond(-0.571358774537, -0.644936902981, 0.287715328713, -0.418121312009);
-        finger_2_rotation_ = Eigen::Quaterniond(0.295890700199, -0.408942259885, -0.577398820031, -0.641736335454);
-        finger_3_rotation_ = Eigen::Quaterniond(0.408269313405, -0.295694272898, -0.643000046283, -0.57656916774);
-    }
-
-    void setTargetCollision(bool option)
-    {
-        if (target_collision_ == option) return;
-        target_collision_ = option;
-        std::cout << CYAN << "[STATE_CHECKER]: Target collision check " << (option ? "enabled" : "disabled") << NC << std::endl;
-    }
-
-    void setNonStaticCollisions(bool option)
-    {
-        if (non_static_collisions_ == option) return;
-        non_static_collisions_ = option;
-        std::cout << CYAN << "[STATE_CHECKER]: Non static collisions check " << (option ? "enabled" : "disabled") << NC << std::endl;
-    }
-
-    void setTargetName(std::string name)
-    {
-        target_name_ = name;
-    }
-
-    void setIKCheck(bool option)
-    {
-        if (check_IK_ == option) return;
-        check_IK_ = option;
-        std::cout << CYAN << "[STATE_CHECKER]: IK check " << (option ? "enabled" : "disabled") << NC << std::endl;
-    }
-
-    bool isValid(const ob::State* state) const
-    {
-        if (!this->checkInReach(state)) { return false; }
-        if (!this->checkCollision(state)) { return false; }
-        if (!this->checkIK(state)) { return false; }
-        return true;
-    }
-
-    bool checkInReach(const ob::State* state) const
-    {
-        const ob::SE3StateSpace::StateType* state3D = state->as<ob::SE3StateSpace::StateType>();
-        return std::sqrt((state3D->getX()*state3D->getX())+(state3D->getY()*state3D->getY())+(state3D->getZ()*state3D->getZ())) <= 0.95;
-    }
-
-    bool checkIK(const ob::State* state) const
-    {
-        // exit here if IK checks are disabled to avoid running the IK solver
-        // which would increase the planning time unnecessarily
-        if (!check_IK_) return true;
-
-        const ob::SE3StateSpace::StateType* state3D = state->as<ob::SE3StateSpace::StateType>();
-        double x = state3D->getX(); double y = state3D->getY(); double z = state3D->getZ();
-
-        Eigen::Quaterniond rotation(state3D->rotation().w,
-                            state3D->rotation().x,
-                            state3D->rotation().y,
-                            state3D->rotation().z);
-
-        std::vector<double> next;
-        bool success = manipulator_->solveIK(next, Eigen::Vector3d(x,y,z), rotation, manipulator_->getInitPose(), true);
-
-        return success;
-    }
-
-    bool checkCollision(const ob::State* state) const
-    {
-        const ob::SE3StateSpace::StateType* state3D = state->as<ob::SE3StateSpace::StateType>();
-        double x = state3D->getX(); double y = state3D->getY(); double z = state3D->getZ();
-
-        int idx = 0;
-        for (size_t i = 0; i < collision_boxes_->size(); i++)
-        {
-            if (collision_boxes_->at(i).name.find("_link_7") != std::string::npos)
-            {
-                idx = i;
-                break;
-            }
-            else if (collision_boxes_->at(i).name.find("_link_6") != std::string::npos)
-            {
-                idx = i;
-            }
-        }
-
-        Eigen::Quaterniond rotation(state3D->rotation().w,
-                            state3D->rotation().x,
-                            state3D->rotation().y,
-                            state3D->rotation().z);
-        
-        //TODO: this bit is very messy, need to clean it up somehow
-
-        util::CollisionGeometry effector = collision_boxes_->at(idx);
-        std::shared_ptr<fcl::CollisionGeometry> effectorbox;
-        effectorbox = std::shared_ptr<fcl::CollisionGeometry>(new fcl::Box(effector.dimension.x, effector.dimension.y, effector.dimension.z));
-        
-        fcl::CollisionObject effectorobj(effectorbox);
-        Eigen::Vector3d effector_translation = rotation.toRotationMatrix() * effector_translation_;
-        fcl::Vec3f effector_xyz(x+effector_translation[0], y+effector_translation[1], z+effector_translation[2]); // set coordinates to be at centre of last link
-        
-        Eigen::Quaterniond q = rotation * Eigen::AngleAxisd(-M_PI, Eigen::Vector3d::UnitX()) * Eigen::AngleAxisd(-M_PI_2, Eigen::Vector3d::UnitZ());
-        fcl::Quaternion3f effector_quat(q.w(), q.x(), q.y(), q.z());
-        
-        effectorobj.setTransform(effector_quat, effector_xyz);
-
-        // ----> fingers
-        // ---> finger 1
-        util::CollisionGeometry kinova_finger1 = collision_boxes_->at(collision_boxes_->size()-3);
-        std::shared_ptr<fcl::CollisionGeometry> finger1box;
-        finger1box = std::shared_ptr<fcl::CollisionGeometry>(new fcl::Box(kinova_finger1.dimension.x, kinova_finger1.dimension.y, kinova_finger1.dimension.z));
-        
-        fcl::CollisionObject finger1obj(finger1box);
-        Eigen::Vector3d finger_1_translation = rotation.toRotationMatrix() * finger_1_translation_;
-        fcl::Vec3f thumb_xyz(x+finger_1_translation[0], y+finger_1_translation[1], z+finger_1_translation[2]); // set coordinates to be centre of thum
-        
-        q = rotation * finger_1_rotation_;
-        fcl::Quaternion3f finger1_quat(q.w(), q.x(), q.y(), q.z());
-        
-        finger1obj.setTransform(finger1_quat, thumb_xyz);
-        // <--- finger 1
-
-        // finger 2
-        util::CollisionGeometry kinova_finger2 = collision_boxes_->at(collision_boxes_->size()-1);
-        std::shared_ptr<fcl::CollisionGeometry> fingerbox2;
-        fingerbox2 = std::shared_ptr<fcl::CollisionGeometry>(new fcl::Box(kinova_finger2.dimension.x, kinova_finger2.dimension.y, kinova_finger2.dimension.z));
-        
-        fcl::CollisionObject finger2obj(fingerbox2);
-        Eigen::Vector3d finger_2_translation = rotation.toRotationMatrix() * finger_2_translation_;
-        fcl::Vec3f finger_xyz(x+finger_2_translation[0], y+finger_2_translation[1], z+finger_2_translation[2]); // set coordinates to be centre of finger
-        
-        q = rotation * finger_2_rotation_;
-        fcl::Quaternion3f finger2_quat(q.w(), q.x(), q.y(), q.z());
-        
-        finger2obj.setTransform(finger2_quat, finger_xyz);
-
-        // finger 3
-        util::CollisionGeometry kinova_finger3 = collision_boxes_->at(collision_boxes_->size()-2);
-        std::shared_ptr<fcl::CollisionGeometry> fingerbox3;
-        fingerbox3 = std::shared_ptr<fcl::CollisionGeometry>(new fcl::Box(kinova_finger3.dimension.x, kinova_finger3.dimension.y, kinova_finger3.dimension.z));
-        
-        fcl::CollisionObject finger3obj(fingerbox3);
-        Eigen::Vector3d finger_3_translation = rotation.toRotationMatrix()*finger_3_translation_;
-        fcl::Vec3f finger_xyz2(x+finger_3_translation[0], y+finger_3_translation[1], z+finger_3_translation[2]); // set coordinates to be centre of finger
-        
-        q = rotation * finger_3_rotation_;
-        fcl::Quaternion3f finger3_quat(q.w(), q.x(), q.y(), q.z());
-
-        finger3obj.setTransform(finger3_quat, finger_xyz2);
-        // <---- fingers
-
-        for (size_t i = 0; i < collision_boxes_->size(); i++)
-        {
-            // not checking for self collisions or collisions of other joints with environment
-            if (collision_boxes_->at(i).name.find(manipulator_->getName()) != std::string::npos)
-            { continue; }
-
-            bool is_static = std::any_of(static_objs_.begin(), static_objs_.end(), [this, i](const std::string& str)
-                { return collision_boxes_->at(i).name.find(str) != std::string::npos; });
-            
-            if ((!is_static && !non_static_collisions_) &&
-                !(collision_boxes_->at(i).name.compare(target_name_) == 0 && target_collision_))
-            { continue; }
-            
-            std::shared_ptr<fcl::CollisionGeometry> box;
-            box = std::shared_ptr<fcl::CollisionGeometry>(new fcl::Box(collision_boxes_->at(i).dimension.x, collision_boxes_->at(i).dimension.y, collision_boxes_->at(i).dimension.z));
-
-            fcl::CollisionObject obj(box);
-            fcl::Vec3f xyz(collision_boxes_->at(i).pose.position.x, collision_boxes_->at(i).pose.position.y, collision_boxes_->at(i).pose.position.z);
-            // fcl::Quaternion3f quat(1, 0, 0, 0);
-            fcl::Quaternion3f quat(collision_boxes_->at(i).pose.orientation.w,
-                            collision_boxes_->at(i).pose.orientation.x,
-                            collision_boxes_->at(i).pose.orientation.y,
-                            collision_boxes_->at(i).pose.orientation.z);
-            obj.setTransform(quat, xyz);
-
-            fcl::CollisionRequest request(1, false, 1, false);
-            fcl::CollisionResult result, finger1_result, finger2_result, finger3_result;
-            fcl::collide(&effectorobj, &obj, request, result);
-            fcl::collide(&finger1obj, &obj, request, finger1_result);
-            fcl::collide(&finger2obj, &obj, request, finger2_result);
-            fcl::collide(&finger3obj, &obj, request, finger3_result);
-
-            if (result.isCollision() || finger1_result.isCollision() || finger2_result.isCollision() || finger3_result.isCollision())
-            {
-                return false;
-            }
-        }
-    
-        return true;
-    }
-    
 private:
     Manipulator* manipulator_;
     const std::vector<util::CollisionGeometry>* collision_boxes_;

--- a/planner/include/planner/util.h
+++ b/planner/include/planner/util.h
@@ -7,18 +7,39 @@
 #include <cmath>
 #include <iostream>
 #include <boost/shared_ptr.hpp>
+#include <eigen3/Eigen/Geometry>
 #include "defines.h"
 
 namespace util
 {
-    typedef struct CollisionGeometry
+    struct CollisionGeometry
     {
         std::string name;
         geometry_msgs::Vector3 min;
         geometry_msgs::Vector3 max;
         geometry_msgs::Vector3 dimension;
         geometry_msgs::Pose pose;
-    } CollisionGeometry;
+    };
+
+    struct GridNode
+    {
+        // Eigen::Vector2d top_left = Eigen::Vector2d(NAN, NAN);
+        Eigen::Vector2d bot_left = Eigen::Vector2d(NAN, NAN);
+        Eigen::Vector2d center = Eigen::Vector2d(NAN, NAN);
+        bool occupied = false;
+        double size = 0.0;
+        Eigen::Quaterniond orientation = Eigen::Quaterniond(NAN, NAN, NAN, NAN);
+    };
+
+    struct Grid2D
+    {
+        int width = 0;
+        int height = 0;
+        double resolution = 0;
+        Eigen::Vector2d origin = Eigen::Vector2d(NAN, NAN);
+        Eigen::Quaterniond rotation = Eigen::Quaterniond(NAN, NAN, NAN, NAN);
+        std::vector<GridNode> nodes;
+    };
 
     inline bool operator==(const CollisionGeometry& lhs, const CollisionGeometry& rhs)
     {
@@ -55,4 +76,7 @@ namespace util
 
         return true;
     }
+
+    Grid2D discretise2DShape(const CollisionGeometry& geom, const std::string& parent_name, const std::string& robot_name,
+        const std::vector<CollisionGeometry>& objects, const double& resolution = 0.02);
 }

--- a/planner/launch/gazebo.launch
+++ b/planner/launch/gazebo.launch
@@ -9,6 +9,7 @@
   <arg name="debug" default="false"/>
   <arg name="use_trajectory_controller" default="true"/>
   <arg name="is7dof" default="true"/>
+  <arg name="surface" default="small_table_link_surface"/>
 
   <include file="$(find kinova_gazebo)/launch/robot_launch.launch">
     <arg name="kinova_robotType" value="$(arg robot)"/>
@@ -20,6 +21,7 @@
     <arg name="debug" value="$(arg debug)"/>
     <arg name="use_trajectory_controller" value="$(arg use_trajectory_controller)"/>
     <arg name="is7dof" value="$(arg is7dof)"/>
+    <arg name="surface" value="$(arg surface)"/>
   </include>
 
 </launch>

--- a/planner/launch/tester.launch
+++ b/planner/launch/tester.launch
@@ -1,11 +1,9 @@
 <launch>
 
     <arg name="num_runs"    default="10" />
-    <arg name="surface"     default="short_table_link_surface" />
 
     <node name="planner_tester_node" pkg="planner" type="tester" output="screen" >
         <param name="num_runs"      value="$(arg num_runs)" />
-        <param name="surface"       value="$(arg surface)" />
     </node>
 
 </launch>

--- a/planner/package.xml
+++ b/planner/package.xml
@@ -19,6 +19,7 @@
   <build_depend>actionlib_msgs</build_depend>
   <build_depend>gazebo_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>nav_msgs</build_depend>
   <build_depend>trac_ik_lib</build_depend>
   <build_depend>gazebo_geometries_plugin</build_depend>
   <build_depend>gazebo_scene_randomiser_plugin</build_depend>
@@ -34,6 +35,7 @@
   <exec_depend>actionlib_msgs</exec_depend>
   <exec_depend>gazebo_msgs</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>nav_msgs</exec_depend>
   <exec_depend>trac_ik_lib</exec_depend>
   <exec_depend>gazebo_geometries_plugin</exec_depend>
   <exec_depend>gazebo_scene_randomiser_plugin</exec_depend>

--- a/planner/src/planner.cpp
+++ b/planner/src/planner.cpp
@@ -265,12 +265,6 @@ void Planner::setGoal(const Eigen::Vector3d& goal, const Eigen::Quaterniond& ori
         << goal_state->rotation().w << "}" << std::endl;
 }
 
-void Planner::setCollisionGeometries(const std::vector<util::CollisionGeometry>& collision_boxes)
-{
-    collision_boxes_.clear();
-    collision_boxes_ = collision_boxes;
-}
-
 void Planner::setTargetGeometry(util::CollisionGeometry geom)
 {
     target_geom_ = geom;

--- a/planner/src/planner.cpp
+++ b/planner/src/planner.cpp
@@ -122,6 +122,8 @@ bool Planner::plan()
                     pdef->getSolutionPath()->as<og::PathGeometric>()->interpolate(path_states_);
                     solutions_.push_back(*pdef->getSolutionPath()->as<og::PathGeometric>());
                     this->publishMarkers();
+
+                    if (save_path_) { this->savePath(); }
                 }
                 else
                 {
@@ -178,6 +180,8 @@ bool Planner::plan()
 
         plan_timer.pause();
 
+        if (save_path_) { this->savePath(); }
+
         exectuion_timer.start();
         controller_.sendAction(traj);
         controller_.closeGripper();
@@ -189,8 +193,6 @@ bool Planner::plan()
     result_.path_found = true;
 
     std::cout << GREEN << "[PLANNER]: Solution found!\n";
-
-    if (save_path_) { this->savePath(); }
 
     // verify grasp attempt
     std::vector<Eigen::Vector3d> positions;
@@ -728,9 +730,11 @@ bool Planner::verifyAndCorrectGraspPose(ob::ScopedState<ob::SE3StateSpace>& stat
     ob::ScopedState<ob::SE3StateSpace> goal_state(space_);
     goal_state = state;
 
-    Eigen::Quaterniond quat = goal_orient_;
+    Eigen::Quaterniond quat(goal_state->rotation().w,
+                            goal_state->rotation().x,
+                            goal_state->rotation().y,
+                            goal_state->rotation().z);
     int num_iterations = 500;
-    double increment = 2*M_PI/num_iterations;
     for (int i = 1; i <= num_iterations; i++)
     {
         for (int j = 0; j <= 1; j++)

--- a/planner/src/state_validity.cpp
+++ b/planner/src/state_validity.cpp
@@ -1,0 +1,204 @@
+#include "planner/state_validity.h"
+
+StateChecker::StateChecker(const ob::SpaceInformationPtr &si, Manipulator* manip, const std::vector<util::CollisionGeometry>* collision_boxes)
+    : ob::StateValidityChecker(si), manipulator_(manip), collision_boxes_(collision_boxes)
+{
+    target_collision_ = true;
+    non_static_collisions_ = false;
+    check_IK_ = false;
+
+    ros::param::param<std::vector<std::string>>("/gazebo/static_objects", static_objs_, {"INVALID"});
+
+    effector_translation_ = Eigen::Vector3d(0, 0.0, -0.12);
+    finger_1_translation_ = Eigen::Vector3d(0.05, 0.0065, -0.032);
+    finger_2_translation_ = Eigen::Vector3d(-0.045, 0.025, -0.032);
+    finger_3_translation_ = Eigen::Vector3d(-0.045, -0.025, -0.032);
+    finger_1_rotation_ = Eigen::Quaterniond(-0.571358774537, -0.644936902981, 0.287715328713, -0.418121312009);
+    finger_2_rotation_ = Eigen::Quaterniond(0.295890700199, -0.408942259885, -0.577398820031, -0.641736335454);
+    finger_3_rotation_ = Eigen::Quaterniond(0.408269313405, -0.295694272898, -0.643000046283, -0.57656916774);
+}
+
+void StateChecker::setTargetCollision(bool option)
+{
+    if (target_collision_ == option) return;
+    target_collision_ = option;
+    std::cout << CYAN << "[STATE_CHECKER]: Target collision check " << (option ? "enabled" : "disabled") << NC << std::endl;
+}
+
+void StateChecker::setNonStaticCollisions(bool option)
+{
+    if (non_static_collisions_ == option) return;
+    non_static_collisions_ = option;
+    std::cout << CYAN << "[STATE_CHECKER]: Non static collisions check " << (option ? "enabled" : "disabled") << NC << std::endl;
+}
+
+void StateChecker::setTargetName(std::string name)
+{
+    target_name_ = name;
+}
+
+void StateChecker::setIKCheck(bool option)
+{
+    if (check_IK_ == option) return;
+    check_IK_ = option;
+    std::cout << CYAN << "[STATE_CHECKER]: IK check " << (option ? "enabled" : "disabled") << NC << std::endl;
+}
+
+bool StateChecker::isValid(const ob::State* state) const
+{
+    if (!this->checkInReach(state)) { return false; }
+    if (!this->checkCollision(state)) { return false; }
+    if (!this->checkIK(state)) { return false; }
+    return true;
+}
+
+bool StateChecker::checkInReach(const ob::State* state) const
+{
+    const ob::SE3StateSpace::StateType* state3D = state->as<ob::SE3StateSpace::StateType>();
+    return std::sqrt((state3D->getX()*state3D->getX())+(state3D->getY()*state3D->getY())+(state3D->getZ()*state3D->getZ())) <= 0.95;
+}
+
+bool StateChecker::checkIK(const ob::State* state) const
+{
+    // exit here if IK checks are disabled to avoid running the IK solver
+    // which would increase the planning time unnecessarily
+    if (!check_IK_) return true;
+
+    const ob::SE3StateSpace::StateType* state3D = state->as<ob::SE3StateSpace::StateType>();
+    double x = state3D->getX(); double y = state3D->getY(); double z = state3D->getZ();
+
+    Eigen::Quaterniond rotation(state3D->rotation().w,
+                                state3D->rotation().x,
+                                state3D->rotation().y,
+                                state3D->rotation().z);
+
+    std::vector<double> next;
+    bool success = manipulator_->solveIK(next, Eigen::Vector3d(x,y,z), rotation, manipulator_->getInitPose(), true);
+
+    return success;
+}
+
+bool StateChecker::checkCollision(const ob::State* state) const
+   {
+    const ob::SE3StateSpace::StateType* state3D = state->as<ob::SE3StateSpace::StateType>();
+    double x = state3D->getX(); double y = state3D->getY(); double z = state3D->getZ();
+
+    int idx = 0;
+    for (size_t i = 0; i < collision_boxes_->size(); i++)
+    {
+        if (collision_boxes_->at(i).name.find("_link_7") != std::string::npos)
+        {
+            idx = i;
+            break;
+        }
+        else if (collision_boxes_->at(i).name.find("_link_6") != std::string::npos)
+        {
+            idx = i;
+        }
+    }
+
+    Eigen::Quaterniond rotation(state3D->rotation().w,
+                                state3D->rotation().x,
+                                state3D->rotation().y,
+                                state3D->rotation().z);
+        
+    //TODO: this bit is very messy, need to clean it up somehow
+
+    util::CollisionGeometry effector = collision_boxes_->at(idx);
+    std::shared_ptr<fcl::CollisionGeometry> effectorbox;
+    effectorbox = std::shared_ptr<fcl::CollisionGeometry>(new fcl::Box(effector.dimension.x, effector.dimension.y, effector.dimension.z));
+        
+    fcl::CollisionObject effectorobj(effectorbox);
+    Eigen::Vector3d effector_translation = rotation.toRotationMatrix() * effector_translation_;
+    fcl::Vec3f effector_xyz(x+effector_translation[0], y+effector_translation[1], z+effector_translation[2]); // set coordinates to be at centre of last link
+        
+    Eigen::Quaterniond q = rotation * Eigen::AngleAxisd(-M_PI, Eigen::Vector3d::UnitX()) * Eigen::AngleAxisd(-M_PI_2, Eigen::Vector3d::UnitZ());
+    fcl::Quaternion3f effector_quat(q.w(), q.x(), q.y(), q.z());
+        
+    effectorobj.setTransform(effector_quat, effector_xyz);
+
+    // ----> fingers
+    // ---> finger 1
+    util::CollisionGeometry kinova_finger1 = collision_boxes_->at(collision_boxes_->size()-3);
+    std::shared_ptr<fcl::CollisionGeometry> finger1box;
+    finger1box = std::shared_ptr<fcl::CollisionGeometry>(new fcl::Box(kinova_finger1.dimension.x, kinova_finger1.dimension.y, kinova_finger1.dimension.z));
+        
+    fcl::CollisionObject finger1obj(finger1box);
+    Eigen::Vector3d finger_1_translation = rotation.toRotationMatrix() * finger_1_translation_;
+    fcl::Vec3f thumb_xyz(x+finger_1_translation[0], y+finger_1_translation[1], z+finger_1_translation[2]); // set coordinates to be centre of thum
+        
+    q = rotation * finger_1_rotation_;
+    fcl::Quaternion3f finger1_quat(q.w(), q.x(), q.y(), q.z());
+        
+    finger1obj.setTransform(finger1_quat, thumb_xyz);
+    // <--- finger 1
+
+    // finger 2
+    util::CollisionGeometry kinova_finger2 = collision_boxes_->at(collision_boxes_->size()-1);
+    std::shared_ptr<fcl::CollisionGeometry> fingerbox2;
+    fingerbox2 = std::shared_ptr<fcl::CollisionGeometry>(new fcl::Box(kinova_finger2.dimension.x, kinova_finger2.dimension.y, kinova_finger2.dimension.z));
+        
+    fcl::CollisionObject finger2obj(fingerbox2);
+    Eigen::Vector3d finger_2_translation = rotation.toRotationMatrix() * finger_2_translation_;
+    fcl::Vec3f finger_xyz(x+finger_2_translation[0], y+finger_2_translation[1], z+finger_2_translation[2]); // set coordinates to be centre of finger
+        
+    q = rotation * finger_2_rotation_;
+    fcl::Quaternion3f finger2_quat(q.w(), q.x(), q.y(), q.z());
+        
+    finger2obj.setTransform(finger2_quat, finger_xyz);
+
+    // finger 3
+    util::CollisionGeometry kinova_finger3 = collision_boxes_->at(collision_boxes_->size()-2);
+    std::shared_ptr<fcl::CollisionGeometry> fingerbox3;
+    fingerbox3 = std::shared_ptr<fcl::CollisionGeometry>(new fcl::Box(kinova_finger3.dimension.x, kinova_finger3.dimension.y, kinova_finger3.dimension.z));
+        
+    fcl::CollisionObject finger3obj(fingerbox3);
+    Eigen::Vector3d finger_3_translation = rotation.toRotationMatrix()*finger_3_translation_;
+    fcl::Vec3f finger_xyz2(x+finger_3_translation[0], y+finger_3_translation[1], z+finger_3_translation[2]); // set coordinates to be centre of finger
+        
+    q = rotation * finger_3_rotation_;
+    fcl::Quaternion3f finger3_quat(q.w(), q.x(), q.y(), q.z());
+
+    finger3obj.setTransform(finger3_quat, finger_xyz2);
+    // <---- fingers
+
+    for (size_t i = 0; i < collision_boxes_->size(); i++)
+    {
+        // not checking for self collisions or collisions of other joints with environment
+        if (collision_boxes_->at(i).name.find(manipulator_->getName()) != std::string::npos)
+        { continue; }
+
+        bool is_static = std::any_of(static_objs_.begin(), static_objs_.end(), [this, i](const std::string& str)
+            { return collision_boxes_->at(i).name.find(str) != std::string::npos; });
+            
+        if ((!is_static && !non_static_collisions_) &&
+            !(collision_boxes_->at(i).name.compare(target_name_) == 0 && target_collision_))
+        { continue; }
+            
+        std::shared_ptr<fcl::CollisionGeometry> box;
+        box = std::shared_ptr<fcl::CollisionGeometry>(new fcl::Box(collision_boxes_->at(i).dimension.x, collision_boxes_->at(i).dimension.y, collision_boxes_->at(i).dimension.z));
+
+        fcl::CollisionObject obj(box);
+        fcl::Vec3f xyz(collision_boxes_->at(i).pose.position.x, collision_boxes_->at(i).pose.position.y, collision_boxes_->at(i).pose.position.z);
+        // fcl::Quaternion3f quat(1, 0, 0, 0);
+        fcl::Quaternion3f quat(collision_boxes_->at(i).pose.orientation.w,
+                            collision_boxes_->at(i).pose.orientation.x,
+                            collision_boxes_->at(i).pose.orientation.y,
+                            collision_boxes_->at(i).pose.orientation.z);
+        obj.setTransform(quat, xyz);
+
+        fcl::CollisionRequest request(1, false, 1, false);
+        fcl::CollisionResult result, finger1_result, finger2_result, finger3_result;
+        fcl::collide(&effectorobj, &obj, request, result);
+        fcl::collide(&finger1obj, &obj, request, finger1_result);
+        fcl::collide(&finger2obj, &obj, request, finger2_result);
+        fcl::collide(&finger3obj, &obj, request, finger3_result);
+
+            if (result.isCollision() || finger1_result.isCollision() || finger2_result.isCollision() || finger3_result.isCollision())
+        {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/planner/src/util.cpp
+++ b/planner/src/util.cpp
@@ -1,0 +1,111 @@
+#include "planner/util.h"
+
+util::Grid2D util::discretise2DShape(const CollisionGeometry& geom, const std::string& parent_name, const std::string& robot_name,
+    const std::vector<CollisionGeometry>& objects, const double& resolution)
+{
+    std::vector<CollisionGeometry> surface_objs;
+    for (CollisionGeometry obj : objects)
+    {
+        if
+        (
+            obj == geom ||
+            obj.pose.position.z - geom.pose.position.z < 0 ||
+            obj.name.find(parent_name) != std::string::npos ||
+            obj.name.find(robot_name) != std::string::npos ||
+            (obj.min.x > geom.max.x &&
+            obj.max.x < geom.min.x &&
+            obj.min.y > geom.max.y &&
+            obj.max.y < geom.min.y)
+        )
+        { continue; }
+
+        // std::cout << obj.name << "\n";
+
+        surface_objs.push_back(obj);
+    }
+    // std::cout << "num surface obj " << surface_objs.size() << "\n";
+    
+    Eigen::Quaterniond surface_rot(geom.pose.orientation.w,
+                            geom.pose.orientation.x,
+                            geom.pose.orientation.y,
+                            geom.pose.orientation.z);
+
+    double yaw = surface_rot.toRotationMatrix().eulerAngles(0, 1, 2).z();
+
+    Eigen::Vector2d surface_bot_left(geom.pose.position.x -geom.dimension.x*0.5,
+                            geom.pose.position.y - geom.dimension.y*0.5);
+    Eigen::Vector2d surface_center(geom.pose.position.x, geom.pose.position.y);
+
+    surface_bot_left = surface_center + (Eigen::Rotation2Dd(yaw) * (surface_bot_left - surface_center));
+
+    Grid2D result;
+    result.width = std::ceil(geom.dimension.x/resolution);
+    result.height = std::ceil(geom.dimension.y/resolution);
+    result.resolution = resolution;
+    result.origin = surface_bot_left;
+    result.rotation = surface_rot;
+    result.nodes.resize(result.width*result.height);
+
+    // std::cout << "Discretising " << geom.name << "\nwidth: " << result.width << " height: " << result.height << "\n";
+    // std::cout << "surface dim: " << geom.dimension.x << " " << geom.dimension.y << "\n";
+    // std::cout << "bot left corner of surface: " << surface_bot_left << std::endl;
+
+    for (int i = 0; i < result.width; i++)
+    {
+        for (int j = 0; j < result.height; j++)
+        {
+            GridNode node;
+
+            node.size = resolution;
+
+            node.bot_left.x() = surface_bot_left.x() + (i*resolution);
+            node.bot_left.y() = surface_bot_left.y() + (j*resolution);
+
+            node.bot_left = surface_bot_left + (Eigen::Rotation2Dd(yaw) * (node.bot_left - surface_bot_left));
+
+            node.center.x() = node.bot_left.x() + (resolution*0.5);
+            node.center.y() = node.bot_left.y() + (resolution*0.5);
+
+            node.center = node.bot_left + (Eigen::Rotation2Dd(yaw) * (node.center - node.bot_left));
+
+            node.orientation = surface_rot;
+
+            // loop through all objects and check if node is occupied
+            for (CollisionGeometry obj : surface_objs)
+            {
+                Eigen::Quaterniond quat(obj.pose.orientation.w,
+                                        obj.pose.orientation.x,
+                                        obj.pose.orientation.y,
+                                        obj.pose.orientation.z);
+
+                Eigen::Vector2d object_pos2d(obj.pose.position.x, obj.pose.position.y);
+
+                // translate point to object coordinate frame i.e. origin of point becomes object center
+                Eigen::Vector2d vec = node.center - object_pos2d;
+                
+                // rotate point in opposite direction of object rotation
+                Eigen::Rotation2Dd center_rot(-1*quat.toRotationMatrix().eulerAngles(0, 1, 2).z());
+                vec = center_rot*vec;
+
+                // translate back to world frame
+                vec = vec + object_pos2d;
+
+                // node.occupied = vec.x() >= obj.min.x &&
+                //                 vec.x() <= obj.max.x &&
+                //                 vec.y() >= obj.min.y &&
+                //                 vec.y() <= obj.max.y;
+
+                node.occupied = vec.x() + (node.size*0.5) > obj.pose.position.x - (obj.dimension.x*0.5) &&
+                                vec.x() - (node.size*0.5) < obj.pose.position.x + (obj.dimension.x*0.5) &&
+                                vec.y() + (node.size*0.5) > obj.pose.position.y - (obj.dimension.y*0.5) &&
+                                vec.y() - (node.size*0.5) < obj.pose.position.y + (obj.dimension.y*0.5);
+
+                if (node.occupied) { break; }
+            }
+
+            result.nodes[i + j*result.width] = node;
+        }
+    }
+
+    return result;
+}

--- a/planner/test/tester.cpp
+++ b/planner/test/tester.cpp
@@ -55,7 +55,7 @@ private:
         }
 
         ros::param::param<int>("~num_runs", num_runs_, 10);
-        ros::param::param<std::string>("~surface", surface_, "short_table_link_surface");
+        ros::param::param<std::string>("/gazebo/surface", surface_, "small_table_link_surface");
         ros::param::param<std::string>("/robot_name", robot_name_, "j2s7s300");
 
         if (num_runs_ <= 0)

--- a/planner/test/tester.cpp
+++ b/planner/test/tester.cpp
@@ -24,6 +24,8 @@ public:
 
     void run()
     {
+        this->initArm();
+        
         int i = 1;
         while (ros::ok())
         {
@@ -47,6 +49,7 @@ private:
         planning_client_ = nh_.serviceClient<planner::start_plan>("/start_plan");
         randomiser_client_ = nh_.serviceClient<gazebo_scene_randomiser_plugin::randomise>("/gazebo/randomise_scene");
         reset_arm_client_ = nh_.serviceClient<std_srvs::Empty>("/reset_arm");
+        init_arm_client_ = nh_.serviceClient<std_srvs::Empty>("/go_to_init");
 
         if (!(planning_client_.exists() && randomiser_client_.exists()))
         {
@@ -67,7 +70,7 @@ private:
         
         auto time = std::time(nullptr);
         std::stringstream ss;
-        ss << ros::package::getPath("planner") + "/test/logs/" << std::put_time(std::localtime(&time), "%b %d %Y")  << "/";
+        ss << ros::package::getPath("planner") + "/test/logs/" << surface_  << "/";
         if (!boost::filesystem::exists(ss.str()))
         {
             if (!boost::filesystem::create_directories(ss.str()))
@@ -78,7 +81,7 @@ private:
             }
         }
 
-        ss << std::put_time(std::localtime(&time), "%X") << ".log";
+        ss << std::put_time(std::localtime(&time), "%b_%d_%Y_%X") << ".log";
 
         log_file_ = ss.str();
 
@@ -91,6 +94,12 @@ private:
     {
         std_srvs::Empty empty_req;
         reset_arm_client_.call(empty_req);
+    }
+
+    void initArm()
+    {
+        std_srvs::Empty empty_req;
+        init_arm_client_.call(empty_req);
     }
 
     void runPlannerAndLog()
@@ -135,6 +144,7 @@ private:
     ros::ServiceClient planning_client_;
     ros::ServiceClient randomiser_client_;
     ros::ServiceClient reset_arm_client_;
+    ros::ServiceClient init_arm_client_;
 
     int num_runs_;
     std::string surface_;


### PR DESCRIPTION
- surface name is now available through a ROS param which is set by an argument through the gazebo launch file
- added grid search for suitable object relocation positions, closes #33 
- added a grid visualisation in Rviz for the discretised surface
- created state_validity.cpp file
- updated main repo README
- add a one-time initialisation of arm joint angles when using the automated testing node